### PR TITLE
Looks like baseurl needs to be configured

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: The Tinyfish blog
 email: matt@bitreef.net
 description: >- # this means to ignore newlines until "baseurl:"
   This blog tracks the progress and the meta discussion around the tinyfish project
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/tinyfish" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: 
 github_username:  bitreef-net


### PR DESCRIPTION
Github Project pages serves off a subpath.  There is a 404 when browsing the docs which are probably because of the missing subpath.

```
GET https://bitreef-net.github.io/assets/css/style.css
```

