### PR TITLE
Adding in Datadog container and moving to docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: 		## Build a container to serve GitHub Pages locally
 docs_build:     ## Build a container to serve GitHub Pages locally
 		docker build -f ./GitHubPages/Dockerfile . --tag=ghpages:base
 
-.PHONY: doc_serve
+.PHONY: docs_serve
 docs_serve:     ## Serve the /docs GitHub Pages locally
 		docker run -v $(CURDIR):/app/ -p 4000:4000 ghpages:base serve --host 0.0.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,13 @@ docs_build:     ## Build a container to serve GitHub Pages locally
 docs_serve:     ## Serve the /docs GitHub Pages locally
 		docker run -v $(CURDIR):/app/ -p 4000:4000 ghpages:base serve --host 0.0.0.0
 
-.PHONY: it_work
-it_work: build run ## Just get the project up and running
-
 .PHONY: help
 help:		# Prints help
 		@echo "Make Targets:\n"
 		@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: run
-run:   		## Run the TinyFish application in a container
-		docker run -p 5000:5000 tinyfish:latest
+run:   		## Run the TinyFish application.  Make sure your datadog api key is in datadog.env
+		docker-compose up
 
 .DEFAULT_GOAL := help

--- a/datadog.env
+++ b/datadog.env
@@ -1,0 +1,3 @@
+DD_API_KEY=#Your_Datadog_Api_Key
+DD_PROCESS_AGENT_ENABLED=true
+SD_BACKEND=docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
     env_file: 
       - datadog.env
-      
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
     env_file: 
       - datadog.env
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  web:
+    build: 
+      context: .
+      dockerfile: ./Python/Dockerfile
+    ports:
+     - "5000:5000"
+  datadog:
+    image: datadog/docker-dd-agent
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    env_file: 
+      - datadog.env


### PR DESCRIPTION
This PR contains two main changes

1. The introduction of [Datadog ](https://www.datadoghq.com/) via the dd-agent container
2. The switch to using docker-compose to allow us to run both the TinyFish and dd-agent containers.

There is also a minor update to the Makefile. 